### PR TITLE
Update default datasource

### DIFF
--- a/ai-foundry/dashboards/ai-foundry.json
+++ b/ai-foundry/dashboards/ai-foundry.json
@@ -164,7 +164,7 @@
           },
           "datasource": {
             "type": "grafana-azure-monitor-datasource",
-            "uid": "${DS_AZURE_MONITOR}"
+            "uid": "${am_ds}"
           },
           "queryType": "Azure Monitor",
           "refId": "inputToken",
@@ -4682,7 +4682,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-azure-monitor-datasource",
-          "uid": "${DS_AZURE_MONITOR}"
+          "uid": "${am_ds}"
         },
         "definition": "",
         "description": "",
@@ -4729,7 +4729,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-azure-monitor-datasource",
-          "uid": "${DS_AZURE_MONITOR}"
+          "uid": "${am_ds}"
         },
         "definition": "",
         "label": "AI Foundry",


### PR DESCRIPTION
Hi, 
Great dashboard thank you for that, just tested it recently and I believe we'll be using it.

Just making a minor suggestion so the initial import in Grafana can be smoother and less datasource changes to be done in variables and visualizations.

When importing the dashboard at the moment (Version 12.2.0 of Grafana) the following issue appear "Datasource ${DS_AZURE_MONITOR} was not found" for the following elements:
- Subscription variable
- AI Foundry variable
- Every visualization

By changing it to the Variable defined then the import is smooth.

(First ever github pull request here so feel free to tell me if I did something wrong)

Thanks for your work.